### PR TITLE
Add support for using the modularized passagemath distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # lefschetz-family
 
+:warning: **This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)).
 
 ## Description
 This Sage package provides a means of efficiently computing periods of complex projective hypersurfaces and elliptic surfaces over $\mathbb P^1$ with certified rigorous precision bounds.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lefschetz-family
 > [!WARNING]  
-> :warning: *This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)). :warning:
+> :warning: **This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)). :warning:
 
 ## Description
 This Sage package provides a means of efficiently computing periods of complex projective hypersurfaces and elliptic surfaces over $\mathbb P^1$ with certified rigorous precision bounds.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lefschetz-family
 
-:warning: **This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)).
+#:warning: **This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)). :warning:
 
 ## Description
 This Sage package provides a means of efficiently computing periods of complex projective hypersurfaces and elliptic surfaces over $\mathbb P^1$ with certified rigorous precision bounds.

--- a/README.md
+++ b/README.md
@@ -372,4 +372,4 @@ Other directions include:
 
 
 ## Project status
-This project is actively being developped.
+This repository is no longer being updated. For the most up to date version of this package, see ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lefschetz-family
-
-#:warning: **This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)). :warning:
+> [!WARNING]  
+> :warning: *This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)). :warning:
 
 ## Description
 This Sage package provides a means of efficiently computing periods of complex projective hypersurfaces and elliptic surfaces over $\mathbb P^1$ with certified rigorous precision bounds.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lefschetz-family
 > [!WARNING]  
-> :warning: **This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family)). :warning:
+> :warning: **This repository has been migrated to Github!** It will no longer be updated. For the most recent version, please see  [https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family). :warning:
 
 ## Description
 This Sage package provides a means of efficiently computing periods of complex projective hypersurfaces and elliptic surfaces over $\mathbb P^1$ with certified rigorous precision bounds.
@@ -372,4 +372,4 @@ Other directions include:
 
 
 ## Project status
-This repository is no longer being updated. For the most up to date version of this package, see ([https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family).
+This repository is no longer being updated. For the most up to date version of this package, see [https://github.com/ericpipha/lefschetz-family](https://github.com/ericpipha/lefschetz-family).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lefschetz-family"
-version = "0.1.13"
+version = "0.1.14"
 authors = [
   { name="Eric Pichon-Pharabod", email="eric.pichon@polytechnique.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,21 @@ dependencies = [
   "delaunay_triangulation",
 ]
 
+[project.optional-dependencies]
+passagemath = [
+  "scipy",
+  "passagemath-combinat",
+  "passagemath-flint",
+  "passagemath-graphs",
+  "passagemath-groups",
+  "passagemath-modules",
+  "passagemath-pari",
+  "passagemath-polyhedra",
+  "passagemath-repl",
+  "passagemath-schemes",
+  "passagemath-symbolics",
+]
+
 [project.urls]
 "Homepage" = "https://gitlab.inria.fr/epichonp/lefschetz-family"
 "Bug Tracker" = "https://gitlab.inria.fr/epichonp/lefschetz-family/issues"

--- a/src/lefschetz_family/context.py
+++ b/src/lefschetz_family/context.py
@@ -60,8 +60,8 @@ class Context(object):
         #     raise TypeError("depth", type(depth))
         # self.depth = depth
 
-        self.CBF = ComplexBallField(500)
-        self.CF = ComplexField(500)
+        self.CBF = ComplexBallField(4*nbits)
+        self.CF = ComplexField(4*nbits)
         self.depth = depth
         self.cutoff_simultaneous_integration = 2
 

--- a/src/lefschetz_family/delaunay.py
+++ b/src/lefschetz_family/delaunay.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from sage.rings.complex_mpfr import ComplexField
 from sage.graphs.graph import Graph

--- a/src/lefschetz_family/delaunayDual.py
+++ b/src/lefschetz_family/delaunayDual.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from sage.rings.rational_field import QQ
 from sage.rings.complex_mpfr import ComplexField

--- a/src/lefschetz_family/doubleCover.py
+++ b/src/lefschetz_family/doubleCover.py
@@ -406,7 +406,7 @@ class DoubleCover(object):
                 while len(exp_divs)!=0:
                     if len([v for v in exp_divs if v * self.intersection_product_modification*exp_divs[0]==0])>0 or len(chosen) == expected_number-1:
                         chosen += [exp_divs[0]]
-                        exp_divs = [v for v in exp_divs if v * self.intersection_product_modification*chosen[-1]==0]
+                        exp_divs = [v for v in exp_divs if v * self.intersection_product_modification * chosen[-1]==0]
                     else:
                         exp_divs = exp_divs[1:]
                 self._exceptional_divisors = chosen + [self.section]
@@ -665,10 +665,11 @@ class DoubleCover(object):
             s=len(self.fibre.homology)
             transition_matrices = self.transition_matrices
             R=len(self.cohomology)
-            r=len(self.thimbles)
             permuting_cycles = self.permuting_cycles
+
+            cohomology_fibre_to_family = self.family._coordinates([self.family.pol.parent()(w) for w in self.fibre.cohomology], self.basepoint)
+            initial_conditions = cohomology_fibre_to_family.inverse()
             
-            integration_correction = diagonal_matrix([1/ZZ(factorial(k)) for k in range(s if self.dim%2==1 else s+1)])
             pM = self.fibre.period_matrix
             if self.dim%2==1:
                 pM = pM.submatrix(0,0,s-1)
@@ -676,7 +677,7 @@ class DoubleCover(object):
             integrated_thimbles = []
             for tM, pcs in zip(transition_matrices, permuting_cycles):
                 for pc in pcs:
-                    integrated_thimbles += [(tM * expand * pM * pc)[:R]]
+                    integrated_thimbles += [(tM * expand * initial_conditions * pM * pc)[:R]]
             self._integrated_thimbles = matrix(integrated_thimbles).transpose()
         return self._integrated_thimbles
     
@@ -686,10 +687,11 @@ class DoubleCover(object):
             s=len(self.fibre.homology)
             transition_matrices = self.transition_matrices_holomorphic
             R=len(self.holomorphic_forms)
-            r=len(self.thimbles)
             permuting_cycles = self.permuting_cycles
+
+            cohomology_fibre_to_family = self.family._coordinates([self.family.pol.parent()(w) for w in self.fibre.cohomology], self.basepoint)
+            initial_conditions = cohomology_fibre_to_family.inverse()
             
-            integration_correction = diagonal_matrix([1/ZZ(factorial(k)) for k in range(s if self.dim%2==1 else s+1)])
             pM = self.fibre.period_matrix
             if self.dim%2==1:
                 pM = pM.submatrix(0,0,s-1)
@@ -697,7 +699,7 @@ class DoubleCover(object):
             integrated_thimbles = []
             for tM, pcs in zip(transition_matrices, permuting_cycles):
                 for pc in pcs:
-                    integrated_thimbles += [(tM * expand * pM * pc)[:R]]
+                    integrated_thimbles += [(tM * expand * initial_conditions * pM * pc)[:R]]
             self._integrated_thimbles_holomorphic = matrix(integrated_thimbles).transpose()
         return self._integrated_thimbles_holomorphic
     

--- a/src/lefschetz_family/doubleCover.py
+++ b/src/lefschetz_family/doubleCover.py
@@ -402,9 +402,13 @@ class DoubleCover(object):
                 short_vectors = [v * others * NS for v in short_vectors]
                 exp_divs = [v+section+fibre for v in short_vectors]
                 chosen=[]
+                expected_number = 1 # this is a temporary workaround
                 while len(exp_divs)!=0:
-                    chosen += [exp_divs[0]]
-                    exp_divs = [v for v in exp_divs if v*self.intersection_product_modification*chosen[-1]==0]
+                    if len([v for v in exp_divs if v * self.intersection_product_modification*exp_divs[0]==0])>0 or len(chosen) == expected_number-1:
+                        chosen += [exp_divs[0]]
+                        exp_divs = [v for v in exp_divs if v * self.intersection_product_modification*chosen[-1]==0]
+                    else:
+                        exp_divs = exp_divs[1:]
                 self._exceptional_divisors = chosen + [self.section]
             else:
                 if self.dim%2 ==1:

--- a/src/lefschetz_family/doubleCover.py
+++ b/src/lefschetz_family/doubleCover.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from .numperiods.familyNew import Family
 from .numperiods.cohomology import Cohomology

--- a/src/lefschetz_family/ellipticSingularity.py
+++ b/src/lefschetz_family/ellipticSingularity.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from ore_algebra import *
 

--- a/src/lefschetz_family/ellipticSurface.py
+++ b/src/lefschetz_family/ellipticSurface.py
@@ -250,7 +250,7 @@ class EllipticSurface(object):
 
     @property
     def primary_lattice(self):
-        return self.monodromy_representation.primary_lattice
+        return self.monodromy_representation.primary_lattice.transpose()
    
     def lift(self, v):
         """Given a combination of thimbles of morsification, gives the corresponding homology class"""
@@ -337,15 +337,15 @@ class EllipticSurface(object):
                 initial_conditions = integration_correction * derivatives_at_basepoint * cohomology_fibre_to_family.inverse() * pM
                 initial_conditions = initial_conditions.submatrix(0,0,transition_matrices[0].ncols())
                 _integrated_thimbles = []
-                for i,ps in enumerate(self.permuting_cycles):
-                    _integrated_thimbles += [(transition_matrices[i]*initial_conditions*p)[0] for p in ps]
+                for i, ps in enumerate(self.permuting_cycles):
+                    _integrated_thimbles += [(transition_matrices[i] * initial_conditions * p)[0] for p in ps]
                 _integrated_thimbles_all += [_integrated_thimbles]
             self._integrated_thimbles = _integrated_thimbles_all
         return self._integrated_thimbles
 
 
     def derivatives_values_at_basepoint(self, w):
-        s=len(self.fibre.extensions)
+        s = len(self.fibre.extensions)
         derivatives = [self.P.parent()(0), w]
         for k in range(s-1):
             derivatives += [self._derivative(derivatives[-1], self.P)] 

--- a/src/lefschetz_family/ellipticSurface.py
+++ b/src/lefschetz_family/ellipticSurface.py
@@ -93,7 +93,7 @@ class EllipticSurface(object):
     def period_matrix(self):
         if not hasattr(self, '_period_matrix'):
             periods_tot = block_matrix([[self.primary_periods, zero_matrix(len(self.holomorphic_forms), len(flatten(self.components_of_singular_fibres))+2)]])
-            self._period_matrix = periods_tot * matrix(self.primary_lattice).transpose().inverse()
+            self._period_matrix = periods_tot * matrix(self.primary_lattice).inverse()
         return self._period_matrix
 
     @property
@@ -250,7 +250,7 @@ class EllipticSurface(object):
 
     @property
     def primary_lattice(self):
-        return self.monodromy_representation.primary_lattice.transpose()
+        return self.monodromy_representation.primary_lattice
    
     def lift(self, v):
         """Given a combination of thimbles of morsification, gives the corresponding homology class"""

--- a/src/lefschetz_family/ellipticSurface.py
+++ b/src/lefschetz_family/ellipticSurface.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 class EllipticSurface(object):
     def __init__(self, P, basepoint=None, fibration=None, **kwds) -> None:
-        """P, a homogeneous polynomial defining an.
+        """P, a homogeneous polynomial defining an elliptic surface.
 
         This class aims at computing an effective basis of the homology group H_n(X), 
         given as lifts of paths through a Lefschetz fibration.
@@ -206,13 +206,13 @@ class EllipticSurface(object):
     def fibre(self):
         if not hasattr(self,'_fibre'):
             self._fibre = Hypersurface(self.P(self.basepoint), nbits=self.ctx.nbits, fibration=self._fibration)
-            # if self._fibre.intersection_product == matrix([[0,-1], [1,0]]):
-                # del self._fibre._monodromy_representation
-                # self._fibre.monodromy_representation._extensions_desingularisation = list(reversed(self._fibre.monodromy_representation.extensions_desingularisation))
-                # self._fibre.monodromy_representation._extensions = list(reversed(self._fibre.monodromy_representation.extensions))
-                # del self._fibre._intersection_product
-                # del self._fibre._intersection_product_modification
-            # assert self._fibre.intersection_product == matrix([[0,1], [-1,0]])
+            if self._fibre.intersection_product == matrix([[0,-1], [1,0]]):
+                del self._fibre._monodromy_representation
+                self._fibre.monodromy_representation._extensions_desingularisation = list(reversed(self._fibre.monodromy_representation.extensions_desingularisation))
+                self._fibre.monodromy_representation._extensions = list(reversed(self._fibre.monodromy_representation.extensions))
+                del self._fibre._intersection_product
+                del self._fibre._intersection_product_modification
+            assert self._fibre.intersection_product == matrix([[0,1], [-1,0]])
         return self._fibre
 
     @property

--- a/src/lefschetz_family/ellipticSurface.py
+++ b/src/lefschetz_family/ellipticSurface.py
@@ -200,7 +200,7 @@ class EllipticSurface(object):
     
     @property
     def monodromy_matrices_morsification(self):
-        return self._monodromy_matrices_morsification
+        return self.monodromy_representation.monodromy_matrices_desingularisation
 
     @property
     def fibre(self):
@@ -409,8 +409,8 @@ class EllipticSurface(object):
     @property
     def trivial_lattice(self):
         if  not hasattr(self, '_trivial_lattice'):
-            singular_components = flatten(self.singular_components)
-            self._trivial_lattice = [self.lift(v) for v in singular_components] + [self.fibre_class, self.section]
+            components_of_singular_fibres = flatten(self.components_of_singular_fibres)
+            self._trivial_lattice = [self.lift(v) for v in components_of_singular_fibres] + [self.fibre_class, self.section]
         return self._trivial_lattice
     
     @property

--- a/src/lefschetz_family/ellipticSurface.py
+++ b/src/lefschetz_family/ellipticSurface.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from .numperiods.family import Family
 from .numperiods.integerRelations import IntegerRelations

--- a/src/lefschetz_family/exceptionalDivisorComputer.py
+++ b/src/lefschetz_family/exceptionalDivisorComputer.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from ore_algebra import *
 

--- a/src/lefschetz_family/hypersurface.py
+++ b/src/lefschetz_family/hypersurface.py
@@ -154,7 +154,7 @@ class Hypersurface(object):
             else:
                 integrated_thimbles_holomorphic = self.integrated_thimbles_holomorphic
                 add = [vector([0]*len(self.monodromy_representation.thimbles))] * len(flatten(self.monodromy_representation.components_of_singular_fibres))
-                add += [vector([0]*len(self.monodromy_representation.thimbles))]*2 if self.dim%2 ==0 else []
+                add += [vector([0]*len(self.monodromy_representation.thimbles))] * 2 if self.dim%2 ==0 else []
                 homology_mat = matrix(self.monodromy_representation.extensions + add).transpose()
                 primary_lattice = self.monodromy_representation.primary_lattice
                 self._holomorphic_period_matrix_modification =  integrated_thimbles_holomorphic * homology_mat * primary_lattice.inverse()
@@ -624,10 +624,11 @@ class Hypersurface(object):
             s=len(self.fibre.homology)
             transition_matrices = self.transition_matrices
             R=len(self.cohomology)
-            r=len(self.thimbles)
             permuting_cycles = self.permuting_cycles
+
+            cohomology_fibre_to_family = self.family._coordinates([self.family.pol.parent()(w) for w in self.fibre.cohomology], self.basepoint)
+            initial_conditions = cohomology_fibre_to_family.inverse()
             
-            integration_correction = diagonal_matrix([1/ZZ(factorial(k)) for k in range(s if self.dim%2==1 else s+1)])
             pM = self.fibre.period_matrix
             if self.dim%2==1:
                 pM = pM.submatrix(0,0,s-1)
@@ -635,7 +636,7 @@ class Hypersurface(object):
             integrated_thimbles = []
             for tM, pcs in zip(transition_matrices, permuting_cycles):
                 for pc in pcs:
-                    integrated_thimbles += [(tM * expand * pM * pc)[:R]]
+                    integrated_thimbles += [(tM * expand * initial_conditions * pM * pc)[:R]]
             self._integrated_thimbles = matrix(integrated_thimbles).transpose()
         return self._integrated_thimbles
     
@@ -645,10 +646,11 @@ class Hypersurface(object):
             s=len(self.fibre.homology)
             transition_matrices = self.transition_matrices_holomorphic
             R=len(self.holomorphic_forms)
-            r=len(self.thimbles)
             permuting_cycles = self.permuting_cycles
+
+            cohomology_fibre_to_family = self.family._coordinates([self.family.pol.parent()(w) for w in self.fibre.cohomology], self.basepoint)
+            initial_conditions = cohomology_fibre_to_family.inverse()
             
-            integration_correction = diagonal_matrix([1/ZZ(factorial(k)) for k in range(s if self.dim%2==1 else s+1)])
             pM = self.fibre.period_matrix
             if self.dim%2==1:
                 pM = pM.submatrix(0,0,s-1)
@@ -656,7 +658,7 @@ class Hypersurface(object):
             integrated_thimbles = []
             for tM, pcs in zip(transition_matrices, permuting_cycles):
                 for pc in pcs:
-                    integrated_thimbles += [(tM * expand * pM * pc)[:R]]
+                    integrated_thimbles += [(tM * expand * initial_conditions * pM * pc)[:R]]
             self._integrated_thimbles_holomorphic = matrix(integrated_thimbles).transpose()
         return self._integrated_thimbles_holomorphic
     

--- a/src/lefschetz_family/hypersurface.py
+++ b/src/lefschetz_family/hypersurface.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 class Hypersurface(object):
-    def __init__(self, P, fibration=None, compute_fundamental_group=True, **kwds):
+    def __init__(self, P, basepoint=None, fibration=None, compute_fundamental_group=True, **kwds):
         """P, a homogeneous polynomial defining a smooth hypersurface X in P^{n+1}.
 
         This class aims at computing an effective basis of the homology group H_n(X), 
@@ -65,6 +65,10 @@ class Hypersurface(object):
             self._fibration = fibration
         if self.dim>=1 and not self.ctx.debug:
             fg = self.fundamental_group # this allows reordering the critical points straight away and prevents shenanigans. There should be a better way to do this
+
+        if basepoint!= None: # it is useful to be able to specify the basepoint to avoid being stuck in arithmetic computations if critical values have very large modulus
+            assert basepoint not in self.critical_values, "basepoint is not regular"
+            self._basepoint = basepoint
     
     
     @property
@@ -315,7 +319,7 @@ class Hypersurface(object):
 
     @property
     def vanishing_cycles(self):
-        return self.monodromy_representation.vanishing_cycles
+        return flatten(self.monodromy_representation.vanishing_cycles_desingularisation)
 
     @property
     def extensions(self):
@@ -513,6 +517,7 @@ class Hypersurface(object):
         if not hasattr(self, '_transition_matrices_holomorphic'):
             if hasattr(self, '_transition_matrices') or self.ctx.simultaneous_integration:
                 r = self.fibre.period_matrix.nrows()
+                r = len(self.fibre.cohomology)
                 R = len(self.cohomology)
                 indices = [self.cohomology.index(w) for w in self.holomorphic_forms]
                 indices += [R+i for i in range(r)]

--- a/src/lefschetz_family/hypersurface.py
+++ b/src/lefschetz_family/hypersurface.py
@@ -394,7 +394,7 @@ class Hypersurface(object):
                 short_vectors = [v * others * NS for v in short_vectors]
                 exp_divs = [v+section+fibre for v in short_vectors]
                 chosen=[]
-                expected_number = self.degree-1
+                expected_number = self.degree-1 # this is a temporary workaround
                 while len(exp_divs)!=0:
                     if len([v for v in exp_divs if v * self.intersection_product_modification*exp_divs[0]==0])>0 or len(chosen) == expected_number-1:
                         chosen += [exp_divs[0]]

--- a/src/lefschetz_family/hypersurface.py
+++ b/src/lefschetz_family/hypersurface.py
@@ -8,7 +8,6 @@ from .numperiods.integerRelations import IntegerRelations
 from ore_algebra import *
 
 from sage.modules.free_module_element import vector
-from sage.rings.complex_arb import ComplexBallField
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.rational_field import QQ
 from sage.rings.qqbar import AlgebraicField

--- a/src/lefschetz_family/hypersurface.py
+++ b/src/lefschetz_family/hypersurface.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from .numperiods.family import Family
 from .numperiods.cohomology import Cohomology

--- a/src/lefschetz_family/integrator.py
+++ b/src/lefschetz_family/integrator.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from ore_algebra import *
 

--- a/src/lefschetz_family/integrator_simultaneous.py
+++ b/src/lefschetz_family/integrator_simultaneous.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from ore_algebra import *
 

--- a/src/lefschetz_family/monodromyRepresentation.py
+++ b/src/lefschetz_family/monodromyRepresentation.py
@@ -59,7 +59,7 @@ class MonodromyRepresentation(object):
     @property
     def intersection_product(self):
         if not hasattr(self,'_intersection_product'):
-            self._intersection_product=self._compute_intersection_product()
+            self._intersection_product = self._compute_intersection_product()
         return self._intersection_product
 
     @property

--- a/src/lefschetz_family/monodromyRepresentation.py
+++ b/src/lefschetz_family/monodromyRepresentation.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from sage.modules.free_module_element import vector
 from sage.matrix.constructor import matrix

--- a/src/lefschetz_family/monodromyRepresentationCurve.py
+++ b/src/lefschetz_family/monodromyRepresentationCurve.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from sage.arith.misc import gcd
 from sage.rings.integer_ring import ZZ

--- a/src/lefschetz_family/monodromyRepresentationEllipticSurface.py
+++ b/src/lefschetz_family/monodromyRepresentationEllipticSurface.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from ore_algebra import *
 

--- a/src/lefschetz_family/monodromyRepresentationGeneric.py
+++ b/src/lefschetz_family/monodromyRepresentationGeneric.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from sage.arith.misc import gcd
 

--- a/src/lefschetz_family/monodromyRepresentationSurface.py
+++ b/src/lefschetz_family/monodromyRepresentationSurface.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from sage.arith.misc import gcd
 from sage.rings.integer_ring import ZZ

--- a/src/lefschetz_family/numperiods/cohomology.py
+++ b/src/lefschetz_family/numperiods/cohomology.py
@@ -4,11 +4,11 @@
 #   - Pierre Lairez (2019): initial implementation
 
 
-from sage.rings.all import *
+#from sage.rings.all import *
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.modules.free_module_element import vector
 from sage.matrix.constructor import Matrix
-from sage.rings.polynomial.polynomial_ring import *
+#from sage.rings.polynomial.polynomial_ring import *
 
 from ..exceptions import NotSmoothError
 

--- a/src/lefschetz_family/numperiods/cohomology.py
+++ b/src/lefschetz_family/numperiods/cohomology.py
@@ -3,12 +3,10 @@
 # AUTHORS:
 #   - Pierre Lairez (2019): initial implementation
 
-
-#from sage.rings.all import *
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.modules.free_module_element import vector
 from sage.matrix.constructor import Matrix
-#from sage.rings.polynomial.polynomial_ring import *
+from sage.modules.free_module_element import vector
+from sage.rings.ideal import Ideal as ideal
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
 from ..exceptions import NotSmoothError
 

--- a/src/lefschetz_family/rootsBraid.py
+++ b/src/lefschetz_family/rootsBraid.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from ore_algebra import *
 

--- a/src/lefschetz_family/simul_integrator_function.py
+++ b/src/lefschetz_family/simul_integrator_function.py
@@ -1,16 +1,14 @@
 import logging
 import time
 
-from sage.all import (
-    block_matrix,
-    ComplexBallField,
-    diagonal_matrix,
-    Frac,
-    matrix,
-    MatrixSpace,
-    RBF,
-    ZZ
-)
+from sage.matrix.special import block_matrix
+from sage.rings.complex_arb import ComplexBallField
+from sage.matrix.special import diagonal_matrix
+from sage.rings.fraction_field import FractionField as Frac
+from sage.matrix.constructor import Matrix as matrix
+from sage.matrix.matrix_space import MatrixSpace
+from sage.rings.real_arb import RBF
+from sage.rings.integer_ring import Z as ZZ
 
 from ore_algebra import OreAlgebra
 from ore_algebra.analytic.accuracy import PrecisionError

--- a/src/lefschetz_family/util.py
+++ b/src/lefschetz_family/util.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from ore_algebra import *
 from sage.rings.complex_mpfr import ComplexField

--- a/src/lefschetz_family/voronoi.py
+++ b/src/lefschetz_family/voronoi.py
@@ -30,6 +30,8 @@ class FundamentalGroupVoronoi(object):
 
 
     def rationalize(self, z):
+        if z.parent()==QQ:
+            return z
         zcc = self.CC(z)
         zr, zi = zcc.real(), zcc.imag()
         zq = Util.simple_rational(zr, self.prec) + I*Util.simple_rational(zi, self.prec)

--- a/src/lefschetz_family/voronoi.py
+++ b/src/lefschetz_family/voronoi.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sage.all
+try:
+    import sage.all
+except ImportError:
+    import sage.all__sagemath_modules
 
 from sage.rings.rational_field import QQ
 from sage.rings.complex_mpfr import ComplexField

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ setenv =
     PYTHONPATH=.
 
 commands =
-    python3 -c 'import lefschetz_family'
+    python3 -c 'from sage.all__sagemath_modules import *; from lefschetz_family import Hypersurface; R = PolynomialRing(QQ, "X,Y,Z"); X, Y, Z = R.gens(); P = X**3+Y**3+Z**3; X = Hypersurface(P); print(X.period_matrix)'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = passagemath
+
+[testenv:.pkg]
+passenv =
+    CPATH
+    LIBRARY_PATH
+
+[testenv:passagemath]
+usedevelop = True
+extras = passagemath
+deps =
+    ore_algebra @ git+https://github.com/mkauers/ore_algebra.git
+
+passenv =
+    CPATH
+    LIBRARY_PATH
+
+setenv =
+    # For access to _doctest_environment.py
+    PYTHONPATH=.
+
+commands =
+    python3 -c 'import lefschetz_family'


### PR DESCRIPTION
Hi @ericpipha, here is a contribution to https://gitlab.inria.fr/epichonp/lefschetz-family for your consideration.

It adds support for using the modularized distributions of the Sage library prepared at https://github.com/passagemath, including testing (with `tox`).
